### PR TITLE
HW3 Ls + Cd. Кащей Владислав

### DIFF
--- a/src/ru/itmo/sd/shell/cli/command/CatCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/CatCommand.kt
@@ -3,6 +3,7 @@ package ru.itmo.sd.shell.cli.command
 import ru.itmo.sd.shell.cli.util.ExecutionResult
 import ru.itmo.sd.shell.cli.util.ReturnCode
 import ru.itmo.sd.shell.cli.util.execution
+import ru.itmo.sd.shell.environment.Environment
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -12,7 +13,7 @@ class CatCommand(
 
     override val name: String = "cat"
 
-    override fun execute(): ExecutionResult {
+    override fun execute(env: Environment): ExecutionResult {
         if (arguments.isNotEmpty()) {
             return processFiles()
         }

--- a/src/ru/itmo/sd/shell/cli/command/CdCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/CdCommand.kt
@@ -3,14 +3,21 @@ package ru.itmo.sd.shell.cli.command
 import ru.itmo.sd.shell.cli.util.ExecutionResult
 import ru.itmo.sd.shell.cli.util.execution
 import ru.itmo.sd.shell.environment.Environment
+import java.io.File
 
-class PwdCommand(
+class CdCommand(
     override val arguments: List<String> = emptyList()
 ) : CliSimpleCommand() {
 
-    override val name: String = "pwd"
+    override val name: String = "cd"
 
     override fun execute(env: Environment): ExecutionResult = execution {
-        writeLine(env.getPwd())
+        if (arguments.isNotEmpty()) {
+            val path = File(arguments[0])
+
+            if (path.exists() && path.isDirectory) {
+                env.setPwd(arguments[0])
+            }
+        }
     }
 }

--- a/src/ru/itmo/sd/shell/cli/command/CliElements.kt
+++ b/src/ru/itmo/sd/shell/cli/command/CliElements.kt
@@ -8,6 +8,7 @@ import ru.itmo.sd.shell.cli.util.PipedInputStrategy
 import ru.itmo.sd.shell.cli.util.PipedOutputStrategy
 import ru.itmo.sd.shell.cli.util.StdInputStrategy
 import ru.itmo.sd.shell.cli.util.StdOutputStrategy
+import ru.itmo.sd.shell.environment.Environment
 import java.io.Closeable
 
 sealed interface CliElement
@@ -18,7 +19,7 @@ sealed class CliCommand : CliElement, Closeable {
     private var inputStrategy: InputStrategy = StdInputStrategy
     private var outputStrategy: OutputStrategy = StdOutputStrategy
 
-    abstract fun execute(): ExecutionResult
+    abstract fun execute(env: Environment): ExecutionResult
 
     fun readLine(): String? = inputStrategy.nextLine()
 

--- a/src/ru/itmo/sd/shell/cli/command/EchoCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/EchoCommand.kt
@@ -2,6 +2,7 @@ package ru.itmo.sd.shell.cli.command
 
 import ru.itmo.sd.shell.cli.util.ExecutionResult
 import ru.itmo.sd.shell.cli.util.execution
+import ru.itmo.sd.shell.environment.Environment
 
 class EchoCommand(
     override val arguments: List<String> = emptyList()
@@ -9,7 +10,7 @@ class EchoCommand(
 
     override val name: String = "echo"
 
-    override fun execute(): ExecutionResult = execution {
+    override fun execute(env: Environment): ExecutionResult = execution {
         val result = arguments.joinToString(separator = " ", postfix = "\n")
         write(result)
     }

--- a/src/ru/itmo/sd/shell/cli/command/ExitCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/ExitCommand.kt
@@ -1,6 +1,7 @@
 package ru.itmo.sd.shell.cli.command
 
 import ru.itmo.sd.shell.cli.util.ExecutionResult
+import ru.itmo.sd.shell.environment.Environment
 import kotlin.system.exitProcess
 
 class ExitCommand(
@@ -9,7 +10,7 @@ class ExitCommand(
 
     override val name: String = "exit"
 
-    override fun execute(): ExecutionResult {
+    override fun execute(env: Environment): ExecutionResult {
         println("*** Exiting shell ***")
         exitProcess(0)
     }

--- a/src/ru/itmo/sd/shell/cli/command/ExternalCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/ExternalCommand.kt
@@ -2,6 +2,7 @@ package ru.itmo.sd.shell.cli.command
 
 import ru.itmo.sd.shell.cli.util.ExecutionResult
 import ru.itmo.sd.shell.cli.util.execution
+import ru.itmo.sd.shell.environment.Environment
 
 class ExternalCommand(
     private val command: String,
@@ -9,7 +10,7 @@ class ExternalCommand(
 ) : CliSimpleCommand() {
     override val name: String = command
 
-    override fun execute(): ExecutionResult = execution {
+    override fun execute(env: Environment): ExecutionResult = execution {
         val process = Runtime.getRuntime().exec("${this@ExternalCommand}")
         val returnCode = process.waitFor()
         val error = process.errorStream.reader().readText()

--- a/src/ru/itmo/sd/shell/cli/command/GrepCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/GrepCommand.kt
@@ -4,6 +4,7 @@ import ru.itmo.sd.shell.cli.util.ExecutionResult
 import ru.itmo.sd.shell.cli.util.ReturnCode
 import ru.itmo.sd.shell.cli.util.execution
 import ru.itmo.sd.shell.cli.util.red
+import ru.itmo.sd.shell.environment.Environment
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -42,7 +43,7 @@ class GrepCommand(override val arguments: List<String>) : CliSimpleCommand() {
 
     override val name: String = "grep"
 
-    override fun execute(): ExecutionResult {
+    override fun execute(env: Environment): ExecutionResult {
         if (fileName != null) {
             return processFile()
         }

--- a/src/ru/itmo/sd/shell/cli/command/LsCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/LsCommand.kt
@@ -1,0 +1,34 @@
+package ru.itmo.sd.shell.cli.command
+
+import ru.itmo.sd.shell.cli.util.ExecutionResult
+import ru.itmo.sd.shell.cli.util.ReturnCode
+import ru.itmo.sd.shell.cli.util.execution
+import ru.itmo.sd.shell.environment.Environment
+import java.io.File
+import java.io.FileNotFoundException
+
+class LsCommand(
+    override val arguments: List<String> = emptyList()
+) : CliSimpleCommand() {
+
+    override val name: String = "ls"
+
+    override fun execute(env: Environment): ExecutionResult = execution {
+
+        val path = File(if (arguments.isEmpty()) {
+            env.getPwd()
+        } else {
+            arguments[0]
+        })
+
+        if (!path.exists() || !path.isDirectory) {
+            code = ReturnCode.FAILURE
+            exception = FileNotFoundException(path.path)
+            return@execution
+        }
+
+        for (file in path.listFiles()!!) {
+            writeLine(file.name)
+        }
+    }
+}

--- a/src/ru/itmo/sd/shell/cli/command/PipelineCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/PipelineCommand.kt
@@ -3,6 +3,7 @@ package ru.itmo.sd.shell.cli.command
 import ru.itmo.sd.shell.cli.util.ExecutionResult
 import ru.itmo.sd.shell.cli.util.ReturnCode
 import ru.itmo.sd.shell.cli.util.runCommand
+import ru.itmo.sd.shell.environment.Environment
 import kotlin.concurrent.thread
 
 class PipelineCommand(val left: CliCommand, val right: CliSimpleCommand) : CliCommand() {
@@ -14,9 +15,9 @@ class PipelineCommand(val left: CliCommand, val right: CliSimpleCommand) : CliCo
         right.connectTo(command)
     }
 
-    override fun execute(): ExecutionResult {
-        val leftRun = thread { runCommand(left) }
-        val result = thread { runCommand(right) }
+    override fun execute(env: Environment): ExecutionResult {
+        val leftRun = thread { runCommand(left, env) }
+        val result = thread { runCommand(right, env) }
         leftRun.join()
         result.join()
         // TODO: process errors

--- a/src/ru/itmo/sd/shell/cli/command/WcCommand.kt
+++ b/src/ru/itmo/sd/shell/cli/command/WcCommand.kt
@@ -3,6 +3,7 @@ package ru.itmo.sd.shell.cli.command
 import ru.itmo.sd.shell.cli.util.ExecutionResult
 import ru.itmo.sd.shell.cli.util.ReturnCode
 import ru.itmo.sd.shell.cli.util.execution
+import ru.itmo.sd.shell.environment.Environment
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -12,7 +13,7 @@ class WcCommand(
 
     override val name: String = "wc"
 
-    override fun execute(): ExecutionResult {
+    override fun execute(env: Environment): ExecutionResult {
         if (arguments.isNotEmpty()) {
             return processFiles()
         }

--- a/src/ru/itmo/sd/shell/cli/util/CliUtils.kt
+++ b/src/ru/itmo/sd/shell/cli/util/CliUtils.kt
@@ -1,6 +1,7 @@
 package ru.itmo.sd.shell.cli.util
 
 import ru.itmo.sd.shell.cli.command.CliCommand
+import ru.itmo.sd.shell.environment.Environment
 
 data class Option(val name: String, val values: List<String>) {
     override fun toString(): String = "-$name ${values.joinToString(" ")}"
@@ -43,8 +44,8 @@ internal fun CliCommand.execution(block: ExecutionResultBuilder.() -> Unit): Exe
 /**
  * Run a given [command].
  */
-fun runCommand(command: CliCommand): ExecutionResult {
-    val result = command.execute()
+fun runCommand(command: CliCommand, env: Environment): ExecutionResult {
+    val result = command.execute(env)
     if (result.code != ReturnCode.OK && result.exception != null) {
         println(result.exception.message)
     }

--- a/src/ru/itmo/sd/shell/environment/Environment.kt
+++ b/src/ru/itmo/sd/shell/environment/Environment.kt
@@ -1,11 +1,17 @@
 package ru.itmo.sd.shell.environment
 
 class Environment {
-    private val variableByName: MutableMap<String, String> = mutableMapOf()
+    private val variableByName: MutableMap<String, String> = System.getenv().toMutableMap()
 
     operator fun set(name: String, value: String) {
         variableByName[name] = value
     }
 
     operator fun get(name: String): String? = variableByName[name]
+
+    fun getPwd(): String = variableByName["PWD"]!!
+
+    fun setPwd(value: String) {
+        variableByName["PWD"] = value
+    }
 }

--- a/src/ru/itmo/sd/shell/environment/Environment.kt
+++ b/src/ru/itmo/sd/shell/environment/Environment.kt
@@ -9,7 +9,7 @@ class Environment {
 
     operator fun get(name: String): String? = variableByName[name]
 
-    fun getPwd(): String = variableByName["PWD"]!!
+    fun getPwd(): String = variableByName["PWD"] ?: System.getProperty("user.dir")
 
     fun setPwd(value: String) {
         variableByName["PWD"] = value

--- a/src/ru/itmo/sd/shell/parser/CommandLexer.kt
+++ b/src/ru/itmo/sd/shell/parser/CommandLexer.kt
@@ -30,6 +30,8 @@ class CommandLexer(private val input: String) {
             CAT -> Token.CAT
             ECHO -> Token.ECHO
             WC -> Token.WC
+            CD -> Token.CD
+            LS -> Token.LS
             PWD -> Token.PWD
             GREP -> Token.GREP
             EXIT -> Token.EXIT
@@ -63,6 +65,8 @@ class CommandLexer(private val input: String) {
         private const val CAT = "cat"
         private const val ECHO = "echo"
         private const val WC = "wc"
+        private const val CD = "cd"
+        private const val LS = "ls"
         private const val PWD = "pwd"
         private const val GREP = "grep"
         private const val EXIT = "exit"

--- a/src/ru/itmo/sd/shell/parser/CommandParser.kt
+++ b/src/ru/itmo/sd/shell/parser/CommandParser.kt
@@ -1,6 +1,7 @@
 package ru.itmo.sd.shell.parser
 
 import ru.itmo.sd.shell.cli.command.CatCommand
+import ru.itmo.sd.shell.cli.command.CdCommand
 import ru.itmo.sd.shell.cli.command.CliCommand
 import ru.itmo.sd.shell.cli.command.CliElement
 import ru.itmo.sd.shell.cli.command.CliSimpleCommand
@@ -9,6 +10,7 @@ import ru.itmo.sd.shell.cli.command.EchoCommand
 import ru.itmo.sd.shell.cli.command.ExitCommand
 import ru.itmo.sd.shell.cli.command.ExternalCommand
 import ru.itmo.sd.shell.cli.command.GrepCommand
+import ru.itmo.sd.shell.cli.command.LsCommand
 import ru.itmo.sd.shell.cli.command.PipelineCommand
 import ru.itmo.sd.shell.cli.command.PwdCommand
 import ru.itmo.sd.shell.cli.command.WcCommand
@@ -64,6 +66,8 @@ class CommandParser {
             Token.ECHO -> ::EchoCommand
             Token.WC -> ::WcCommand
             Token.PWD -> ::PwdCommand
+            Token.CD -> ::CdCommand
+            Token.LS -> ::LsCommand
             Token.GREP -> ::GrepCommand
             Token.EXIT -> ::ExitCommand
             Token.TEXT -> {

--- a/src/ru/itmo/sd/shell/parser/Token.kt
+++ b/src/ru/itmo/sd/shell/parser/Token.kt
@@ -5,6 +5,8 @@ enum class Token {
     ECHO,   // echo
     WC,     // wc
     PWD,    // pwd
+    CD,    // cd
+    LS,    // cd
     GREP,    // grep
     EXIT,   // exit
     TEXT,   // <some text>

--- a/src/ru/itmo/sd/shell/processor/CommandProcessor.kt
+++ b/src/ru/itmo/sd/shell/processor/CommandProcessor.kt
@@ -30,7 +30,7 @@ class CommandProcessor {
                 environment[name] = value
             }
             is CliCommand -> {
-                runCommand(cliElement)
+                runCommand(cliElement, environment)
             }
         }
     }.onFailure {

--- a/test/ru/itmo/sd/shell/cli/command/AbstractCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/AbstractCommandTest.kt
@@ -3,13 +3,14 @@ package ru.itmo.sd.shell.cli.command
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import ru.itmo.sd.shell.cli.command.util.Utils
+import ru.itmo.sd.shell.environment.Environment
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
 
 abstract class AbstractCommandTest {
     protected lateinit var outputStream: ByteArrayOutputStream
-
+    protected val env = Environment()
     @BeforeEach
     fun setupStreams() {
         outputStream = ByteArrayOutputStream()
@@ -23,7 +24,6 @@ abstract class AbstractCommandTest {
 
     companion object {
         val testFiles = Utils.testFiles
-        val testDirs = Utils.testDirs
 
         val filesContent: Map<String, String> =
             testFiles.associateWith { File(it).readText() }

--- a/test/ru/itmo/sd/shell/cli/command/CatCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/CatCommandTest.kt
@@ -13,7 +13,7 @@ class CatCommandTest : AbstractSimpleCommandTest() {
     fun testCat(fileNames: List<String>) {
         val cat = command(fileNames)
         val expected = expectedCat(fileNames)
-        val (code, _) = cat.execute()
+        val (code, _) = cat.execute(env)
         assertEquals(0, code)
         assertEquals(expected, outputStream.toString())
     }

--- a/test/ru/itmo/sd/shell/cli/command/CdCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/CdCommandTest.kt
@@ -1,0 +1,29 @@
+package ru.itmo.sd.shell.cli.command
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class CdCommandTest : AbstractSimpleCommandTest() {
+
+    @Test
+    fun testCdWithoutArgs() {
+        val oldWorkingDir = env.getPwd()
+        val cd = command()
+        val (code, _) = cd.execute(env)
+        Assertions.assertEquals(0, code)
+        Assertions.assertEquals(oldWorkingDir, env.getPwd())
+    }
+
+    @Test
+    fun testCdWithArgs() {
+        val arg = File(".").absolutePath
+        val cd = command(listOf(arg))
+        val (code, _) = cd.execute(env)
+        Assertions.assertEquals(0, code)
+        Assertions.assertEquals(arg, env.getPwd())
+    }
+
+    override fun command(arguments: List<String>): CliSimpleCommand =
+        CdCommand(arguments = arguments)
+}

--- a/test/ru/itmo/sd/shell/cli/command/EchoCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/EchoCommandTest.kt
@@ -12,7 +12,7 @@ class EchoCommandTest : AbstractSimpleCommandTest() {
     fun testEcho(arguments: List<String>) {
         val echo = command(arguments)
         val expected = expectedEcho(arguments)
-        val (code, _) = echo.execute()
+        val (code, _) = echo.execute(env)
         Assertions.assertEquals(0, code)
         Assertions.assertEquals(expected, outputStream.toString())
     }

--- a/test/ru/itmo/sd/shell/cli/command/ExternalCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/ExternalCommandTest.kt
@@ -17,7 +17,7 @@ class ExternalCommandTest : AbstractSimpleCommandTest() {
         assertEquals(0, expectedCode)
         assertTrue(error.isEmpty())
 
-        val (code, _) = command(listOf(cmdName)).execute()
+        val (code, _) = command(listOf(cmdName)).execute(env)
 
         assertEquals(expectedCode, code)
         assertEquals(expected, outputStream.toString())
@@ -26,7 +26,7 @@ class ExternalCommandTest : AbstractSimpleCommandTest() {
     @Test
     fun testMissingCommand() {
         assertThrows<Exception> {
-            command(listOf("abc")).execute()
+            command(listOf("abc")).execute(env)
         }
     }
 

--- a/test/ru/itmo/sd/shell/cli/command/GrepCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/GrepCommandTest.kt
@@ -13,7 +13,7 @@ class GrepCommandTest : AbstractSimpleCommandTest() {
     @MethodSource("argumentProvider")
     fun testGrep(expected: String, arguments: List<String>) {
         val grep = command(arguments)
-        val (code, _) = grep.execute()
+        val (code, _) = grep.execute(env)
         assertEquals(0, code)
         assertEquals(expected, outputStream.toString())
     }

--- a/test/ru/itmo/sd/shell/cli/command/LsCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/LsCommandTest.kt
@@ -1,0 +1,27 @@
+package ru.itmo.sd.shell.cli.command
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class LsCommandTest : AbstractSimpleCommandTest() {
+
+    @Test
+    fun testLsWithoutArgs() {
+        val ls = command()
+        val (code, _) = ls.execute(env)
+        Assertions.assertEquals(0, code)
+        Assertions.assertEquals(File(env.getPwd()).listFiles()?.joinToString("\n") { it.name }+"\n", outputStream.toString())
+    }
+
+    @Test
+    fun testLsWithArgs() {
+        val ls = command(listOf("."))
+        val (code, _) = ls.execute(env)
+        Assertions.assertEquals(0, code)
+        Assertions.assertEquals(File(".").listFiles()?.joinToString("\n") { it.name }+"\n", outputStream.toString())
+    }
+
+    override fun command(arguments: List<String>): CliSimpleCommand =
+        LsCommand(arguments = arguments)
+}

--- a/test/ru/itmo/sd/shell/cli/command/PipelineCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/PipelineCommandTest.kt
@@ -11,7 +11,7 @@ class PipelineCommandTest : AbstractCommandTest() {
         val wc = WcCommand()
 
         val pipelineCmd = PipelineCommand(pwd, wc)
-        val (code, _) = pipelineCmd.execute()
+        val (code, _) = pipelineCmd.execute(env)
         val directory = System.getProperty("user.dir")
         val expected = "1 1 ${directory.length}\n"
 

--- a/test/ru/itmo/sd/shell/cli/command/PwdCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/PwdCommandTest.kt
@@ -8,7 +8,7 @@ class PwdCommandTest : AbstractSimpleCommandTest() {
     @Test
     fun testPwd() {
         val pwd = command()
-        val (code, _) = pwd.execute()
+        val (code, _) = pwd.execute(env)
         val expected = "${System.getProperty("user.dir")}\n"
         Assertions.assertEquals(0, code)
         Assertions.assertEquals(expected, outputStream.toString())

--- a/test/ru/itmo/sd/shell/cli/command/WcCommandTest.kt
+++ b/test/ru/itmo/sd/shell/cli/command/WcCommandTest.kt
@@ -16,7 +16,7 @@ class WcCommandTest : AbstractSimpleCommandTest() {
         mockkStatic(CONSOLE_KT)
         every { readLine() } returnsMany input andThen null
         val wc = command()
-        val (code, _) = wc.execute()
+        val (code, _) = wc.execute(env)
 
         assertEquals(0, code)
         assertEquals(expected, outputStream.toString())


### PR DESCRIPTION
В целом, я не увидел каких-либо проблем при добавлении нового функционала кроме одной. Команда не может никак повлиять на Environment, что не очень логично. Поэтому добавил передачу environment в команды, инициализировал его через System.getenv() и таким образом получил хранение PWD в environment. Также думаю можно переписать тогда присвоение новой переменной в среде как обычную команду и не нужно будет реализовывать отдельную ветку в CommandProcessor:27:9